### PR TITLE
Fix build on Linux with non-gcc compilers

### DIFF
--- a/win-linux/ASCDocumentEditor.pro
+++ b/win-linux/ASCDocumentEditor.pro
@@ -17,7 +17,7 @@ SOURCES += \
 
 RC_FILE = $$PWD/version.rc
 
-linux-g++ {
+linux-* {
     LIBS += -L$$PWD/$$CORE_LIB_PATH/lib/$$PLATFORM_BUILD -lascdocumentscore
     DEFINES += LINUX _LINUX _LINUX_QT _GLIBCXX_USE_CXX11_ABI=0
 

--- a/win-linux/defaults.pri
+++ b/win-linux/defaults.pri
@@ -65,7 +65,7 @@ SOURCES += \
 
 RESOURCES += $$PWD/resources.qrc
 
-linux-g++ {
+linux-* {
     contains(QMAKE_HOST.arch, x86_64):{
         PLATFORM_BUILD = linux_64
     } else {


### PR DESCRIPTION
Fix building on Linux with non-gcc compilers by not hardcoding the linux-g++
combo

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>