### PR TITLE
Add support for old version of dpkg

### DIFF
--- a/win-linux/package/linux/Makefile
+++ b/win-linux/package/linux/Makefile
@@ -284,7 +284,7 @@ $(RPM): desktopeditor rpm/$(PACKAGE_NAME).spec
 		package.spec
 
 $(DEB): desktopeditor $(DEB_DEPS)
-	cd deb && dpkg-buildpackage -b --no-sign
+	cd deb && dpkg-buildpackage -b -uc -us
 	mkdir -p $(DEB_PACKAGE_DIR)
 	mv -f *.deb *.ddeb *.buildinfo *.changes -t $(DEB_PACKAGE_DIR)
 


### PR DESCRIPTION
from dpkg-buildpackage 1.17.5 man
```
       -us    Do not sign the source package.

       -uc    Do not sign the .changes file.
```

from dpkg-buildpackage 1.19.0.5 man
```
       -us, --unsigned-source
              Do not sign the source package (long option since dpkg 1.18.8).

       -ui, --unsigned-buildinfo
              Do not sign the .buildinfo file (since dpkg 1.18.19).

       -uc, --unsigned-changes
              Do not sign the .buildinfo and .changes files (long option since
              dpkg 1.18.8).

       --no-sign
              Do not sign any file, this  includes  the  source  package,  the
              .buildinfo file and the .changes file (since dpkg 1.18.20).
```