### PR TITLE
Fixed bug 54777: focus after saving in the editor window

### DIFF
--- a/win-linux/src/windows/ceditorwindow_p.h
+++ b/win-linux/src/windows/ceditorwindow_p.h
@@ -209,6 +209,7 @@ public:
             } else {
                 QJsonObject _json_obj{{"action", action}};
                 AscAppManager::sendCommandTo(panel()->cef(), L"button:click", Utils::stringifyJson(_json_obj).toStdWString());
+                window->focus();
             }
         });
 


### PR DESCRIPTION
Fixed bug 54777: focus after saving in the editor window 