### PR TITLE
Fixed maximized window state and raise

### DIFF
--- a/win-linux/src/cascapplicationmanagerwrapper.cpp
+++ b/win-linux/src/cascapplicationmanagerwrapper.cpp
@@ -879,7 +879,9 @@ void CAscApplicationManagerWrapper::handleInputCmd(const std::vector<wstring>& v
         if ( panel ) {
             if ( open_in_new_window ) {
                 CEditorWindow * editor_win = new CEditorWindow(_start_rect, panel);
-                editor_win->show(false);
+                bool isMaximized = mainWindow() ? mainWindow()->windowState().testFlag(Qt::WindowMaximized) :
+                                                  reg_user.value("maximized", false).toBool();
+                editor_win->show(isMaximized);
 
                 _app.m_vecEditors.push_back(size_t(editor_win));
                 if ( editor_win->isCustomWindowStyle() )
@@ -1021,8 +1023,8 @@ void CAscApplicationManagerWrapper::initializeApp()
             if ( !vec_inargs.empty() )
                 handleInputCmd(vec_inargs);
 
-            if ( mainWindow() )
-                mainWindow()->bringToTop();
+            //if ( mainWindow() )
+               // mainWindow()->bringToTop();
         });
     }
 

--- a/win-linux/src/cascapplicationmanagerwrapper.cpp
+++ b/win-linux/src/cascapplicationmanagerwrapper.cpp
@@ -882,6 +882,7 @@ void CAscApplicationManagerWrapper::handleInputCmd(const std::vector<wstring>& v
                 bool isMaximized = mainWindow() ? mainWindow()->windowState().testFlag(Qt::WindowMaximized) :
                                                   reg_user.value("maximized", false).toBool();
                 editor_win->show(isMaximized);
+                editor_win->bringToTop();
 
                 _app.m_vecEditors.push_back(size_t(editor_win));
                 if ( editor_win->isCustomWindowStyle() )

--- a/win-linux/src/windows/ceditorwindow.cpp
+++ b/win-linux/src/windows/ceditorwindow.cpp
@@ -419,6 +419,7 @@ void CEditorWindow::onCloseEvent()
 {
     if ( m_pMainView ) {
         if ( closeWindow() == MODAL_RESULT_YES ) {
+            CWindowBase::saveWindowState();
             hide();
         }
     }

--- a/win-linux/src/windows/cmainwindow.cpp
+++ b/win-linux/src/windows/cmainwindow.cpp
@@ -261,15 +261,7 @@ void CMainWindow::focus()
 
 void CMainWindow::onCloseEvent()
 {
-    if (windowState() != Qt::WindowFullScreen && isVisible()) {
-        GET_REGISTRY_USER(reg_user)
-        if (isMaximized()) {
-            reg_user.setValue("maximized", true);
-        } else {
-            reg_user.remove("maximized");
-            reg_user.setValue("position", normalGeometry());
-        }
-    }
+    CWindowBase::saveWindowState();
     AscAppManager::closeMainWindow();
 }
 

--- a/win-linux/src/windows/cwindowbase.cpp
+++ b/win-linux/src/windows/cwindowbase.cpp
@@ -35,9 +35,8 @@
 #include "utils.h"
 #include "ccefeventsgate.h"
 #include "clangater.h"
-#ifdef __linux__
-# include "defines.h"
-#else
+#include "defines.h"
+#ifdef _WIN32
 # include "windows/platform_win/caption.h"
 # if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
 #  include <QOperatingSystemVersion>
@@ -200,6 +199,19 @@ QWidget* CWindowBase::createTopPanel(QWidget *parent)
 #endif
     }
     return _boxTitleBtns;
+}
+
+void CWindowBase::saveWindowState()
+{
+    if (!windowState().testFlag(Qt::WindowFullScreen)) {
+        GET_REGISTRY_USER(reg_user)
+        if (windowState().testFlag(Qt::WindowMaximized)) {
+            reg_user.setValue("maximized", true);
+        } else {
+            reg_user.remove("maximized");
+            reg_user.setValue("position", normalGeometry());
+        }
+    }
 }
 
 void CWindowBase::setIsCustomWindowStyle(bool custom)

--- a/win-linux/src/windows/cwindowbase.h
+++ b/win-linux/src/windows/cwindowbase.h
@@ -80,6 +80,7 @@ protected:
 
     QPushButton* createToolButton(QWidget * parent, const QString& name);
     QWidget* createTopPanel(QWidget *parent);
+    void saveWindowState();
     void setIsCustomWindowStyle(bool);
     virtual void setScreenScalingFactor(double);
     virtual void applyWindowState();

--- a/win-linux/src/windows/platform_win/cwindowplatform.cpp
+++ b/win-linux/src/windows/platform_win/cwindowplatform.cpp
@@ -119,9 +119,16 @@ void CWindowPlatform::bringToTop()
     if (IsIconic(m_hWnd)) {
         ShowWindow(m_hWnd, SW_SHOWNORMAL);
     }
-    SetForegroundWindow(m_hWnd);
-    SetFocus(m_hWnd);
-    SetActiveWindow(m_hWnd);
+    HWND hWndFrg = ::GetForegroundWindow();
+    DWORD appID = ::GetCurrentThreadId();
+    DWORD frgID = ::GetWindowThreadProcessId(hWndFrg, NULL);
+    ::AttachThreadInput(frgID, appID, TRUE);
+    ::SetWindowPos(m_hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+    ::SetWindowPos(m_hWnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+    ::SetForegroundWindow(m_hWnd);
+    ::SetFocus(m_hWnd);
+    ::SetActiveWindow(m_hWnd);
+    ::AttachThreadInput(frgID, appID, FALSE);
 }
 
 void CWindowPlatform::show(bool maximized)


### PR DESCRIPTION
Fixed bug 58399: ignore Maximize mode when opening documents in a separate window,
Fixed bug 58402: an application minimized in Maximize mode loses its state when a document is opened with it,
Fixed bug 58401: a running application does not come to the foreground.