### PR TITLE
Fix typos in Turkish Translation

### DIFF
--- a/common/loginpage/locale/tr.js
+++ b/common/loginpage/locale/tr.js
@@ -88,6 +88,6 @@ l10n.tr = {
     settOptThemeClassicLight: 'Klasik Aydınlık',
     settOptThemeDark: 'Karanlık',
     settOptLaunchMode: 'Dosya aç',
-    settOptLaunchInTab: 'Sekmed',
+    settOptLaunchInTab: 'Sekmede',
     settOptLaunchInWindow: 'Pencerede',
 }

--- a/win-linux/langs/tr.ts
+++ b/win-linux/langs/tr.ts
@@ -30,7 +30,7 @@
     <message>
         <location filename="../src/cascapplicationmanagerwrapper.cpp" line="1829"/>
         <source>Book%1.xlsx</source>
-        <translation>Kitağ%1.xlsx</translation>
+        <translation>Kitap%1.xlsx</translation>
     </message>
     <message>
         <location filename="../src/cascapplicationmanagerwrapper.cpp" line="1830"/>


### PR DESCRIPTION
Fixed typos:
* `kitap` word that means `Book`,
* `sekmede` word that means `Launch In Tab`