### PR TITLE
Fix #2312: skip CUPS discovery when local socket is missing

### DIFF
--- a/win-linux/src/cprintdata.cpp
+++ b/win-linux/src/cprintdata.cpp
@@ -36,6 +36,7 @@
 #include "cprintdata.h"
 #include "utils.h"
 #include "defines.h"
+#include "cupsavailability.h"
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -46,6 +47,7 @@
 #ifdef __linux__
 # include <cups/cups.h>
 # include <cups/ppd.h>
+# include <QDir>
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
@@ -194,9 +196,16 @@ public:
             if ( native.contains("printer") ) {
                 QString printerName = native["printer"].toString();
                 if ( !printerName.isEmpty() ) {
-                    QPrinterInfo info{QPrinterInfo::printerInfo(printerName)};
-                    if ( !info.isNull() )
-                        printer_info = info;
+#ifdef __linux__
+                    if (!cupsLocalSocketAvailable() && !cupsRemoteServerConfigured())
+                        printer_info = QPrinterInfo();
+                    else
+#endif
+                    {
+                        QPrinterInfo info{QPrinterInfo::printerInfo(printerName)};
+                        if ( !info.isNull() )
+                            printer_info = info;
+                    }
                 }
             }
 
@@ -355,6 +364,13 @@ public:
             }
         }
 #else
+#ifdef __linux__
+        if (!cupsLocalSocketAvailable() && !cupsRemoteServerConfigured()) {
+            QJsonObject rootObject;
+            rootObject["printers"] = printersArray;
+            return rootObject;
+        }
+#endif
         cups_dest_t *dests = nullptr;
         int num_dests = cupsGetDests(&dests);
         if (dests) {
@@ -465,6 +481,10 @@ auto CPrintData::init(int senderid, NSEditorApi::CAscPrintEnd * data) -> void
 auto CPrintData::printerInfo() const -> QPrinterInfo
 {
     if ( m_priv->printer_info.printerName().isEmpty() ) {
+#ifdef __linux__
+        if (!cupsLocalSocketAvailable() && !cupsRemoteServerConfigured())
+            return QPrinterInfo();
+#endif
         GET_REGISTRY_USER(reg_user);
 
         QString last_printer_name = reg_user.value("lastPrinterName").toString();

--- a/win-linux/src/cupsavailability.h
+++ b/win-linux/src/cupsavailability.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) Ascensio System SIA, 2009-2026
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation, together with the
+ * additional terms provided in the LICENSE file.
+ */
+
+#ifndef CUPSAVAILABILITY_H
+#define CUPSAVAILABILITY_H
+
+#include <QDir>
+#include <QFile>
+
+#ifdef __linux__
+inline bool cupsLocalSocketAvailable()
+{
+    return QFile::exists(QStringLiteral("/run/cups/cups.sock"))
+        || QFile::exists(QStringLiteral("/var/run/cups/cups.sock"));
+}
+
+inline bool cupsRemoteServerConfigured()
+{
+    if (qEnvironmentVariableIsSet("CUPS_SERVER"))
+        return true;
+
+    QFile file(QDir::homePath() + QStringLiteral("/.cups/client.conf"));
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    while (!file.atEnd()) {
+        const QString line = QString::fromUtf8(file.readLine()).trimmed();
+        if (line.startsWith(QLatin1String("ServerName")) || line.startsWith(QLatin1String("ServerHostname")))
+            return true;
+    }
+    return false;
+}
+#endif
+
+#endif // CUPSAVAILABILITY_H

--- a/win-linux/src/utils.cpp
+++ b/win-linux/src/utils.cpp
@@ -53,6 +53,7 @@
 #include <QProcess>
 #include "cascapplicationmanagerwrapper.h"
 #include "qdpichecker.h"
+#include "cupsavailability.h"
 #include "common/File.h"
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 # include <QDesktopWidget>
@@ -177,6 +178,11 @@ namespace EditorJSVariables {
                 vars_object["helpUrl"] = URL_WEBAPPS_HELP;
 #endif
         }
+#ifdef __linux__
+        if (!cupsLocalSocketAvailable() && !cupsRemoteServerConfigured())
+            vars_object["defaultPrinterName"] = QString();
+        else
+#endif
         vars_object["defaultPrinterName"] = QPrinterInfo::defaultPrinterName();
     }
 


### PR DESCRIPTION
Closes #2312

Skip every CUPS query on Linux when neither the local Unix socket (/run/cups/cups.sock or /var/run/cups/cups.sock) nor a remote server (CUPS_SERVER or ServerName/ServerHostname in ~/.cups/client.conf) is configured.

### Problem

cupsGetDests() blocks the main thread for several seconds at startup when CUPS is unavailable but the TCP connection to port 631 does not fail fast (e.g. IPv6 disabled and/or an unreachable print server). The freeze happens before the window is shown:

1. EditorJSVariables::init() reads the default printer name via QPrinterInfo::defaultPrinterName() (loads the bundled Qt CUPS print support plugin and queries CUPS synchronously on the main thread).
2. The async printers capabilities query runs cupsGetDests() in a worker thread.
3. The print flow queries CUPS via QPrinterInfo when the user prints.

### Fix

New cupsavailability.h with shared helpers cupsLocalSocketAvailable() and cupsRemoteServerConfigured(). When CUPS is not reachable at all (no local socket, no remote server configured), skip the queries instead of letting libcups fall back to TCP localhost:631 and hang in connect(EINPROGRESS)/poll(250ms) loops.

### Validation

Measured with a script that polls the X window list (host: Arch Linux, xprop-based):

| Scenario | Packaged 9.4.0-1 (no fix) | Fixed build |
|---|---|---|
| CUPS active | ~1.28s | ~1.28s (no regression) |
| CUPS stopped (ECONNREFUSED) | ~0.31s | ~0.31s |
| CUPS stopped + unreachable server (EINPROGRESS, nft DROP on 631) | no window in 15s | ~0.31s |

strace: with the fix, zero connects to port 631 when CUPS is absent (the main thread never loads the Qt print support plugin); with CUPS active, only the local socket is used.