### PR TITLE
fix bug 74361: empty filter name in xdg-desktop-portal save dialog

### DIFF
--- a/win-linux/src/components/cfiledialog.cpp
+++ b/win-linux/src/components/cfiledialog.cpp
@@ -85,6 +85,8 @@ CFileDialogWrapper::CFileDialogWrapper(QWidget * parent) : QObject(parent)
 	m_mapFilters[AVS_OFFICESTUDIO_FILE_DOCUMENT_OFORM_PDF]   = tr("ONLYOFFICE Form Document (*.pdf)");
 	m_mapFilters[AVS_OFFICESTUDIO_FILE_DOCUMENT_DOCXF]       = tr("DOCXF Document (*.docxf)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_DOCUMENT_MD]          = tr("Markdown File (*.md)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_DOCUMENT_DOTM]        = tr("Macro-enabled Document Template (*.dotm)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_DOCUMENT_OFORM]       = tr("ONLYOFFICE Form (*.oform)");
 
     m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_PPTX]   = tr("PPTX File (*.pptx)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_PPT]    = tr("PPT File (*.ppt)");
@@ -93,6 +95,8 @@ CFileDialogWrapper::CFileDialogWrapper(QWidget * parent) : QObject(parent)
     m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_OTP]    = tr("OpenDocument Presentation Template") + " (*.otp)";
     m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_PPSX]   = tr("PPSX File (*.ppsx)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_PPTM]   = tr("Macro-enabled Presentation File (*.pptm)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_POTM]   = tr("Macro-enabled Presentation Template (*.potm)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_PRESENTATION_PPSM]   = tr("Macro-enabled PPS File (*.ppsm)");
 
     m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLSX]    = tr("XLSX File (*.xlsx)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLTX]    = tr("Spreadsheet template") + " (*.xltx)";
@@ -102,12 +106,16 @@ CFileDialogWrapper::CFileDialogWrapper(QWidget * parent) : QObject(parent)
     m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_ODS]     = tr("ODS File (*.ods)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_OTS]     = tr("OpenDocument Spreadsheet Template") + " (*.ots)";
     m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_CSV]     = tr("CSV File (*.csv)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_TSV]     = tr("TSV File (*.tsv)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_SCSV]    = tr("SCSV File (*.csv)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLSM]    = tr("Macro-enabled Spreadsheet File (*.xlsm)");
 
     m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_PDF]   = tr("PDF File (*.pdf)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_PDFA]  = tr("PDFA File (*.pdf)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_DJVU]  = tr("DJVU File (*.djvu)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_XPS]   = tr("XPS File (*.xps)");
     m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_SVG]   = tr("SVG Image (*.svg)");
+    m_mapFilters[AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_OFD]   = tr("OFD File (*.ofd)");
 
     m_mapFilters[AVS_OFFICESTUDIO_FILE_DRAW_VSDX]           = tr("VSDX File") + " (*.vsdx)";
     m_mapFilters[AVS_OFFICESTUDIO_FILE_DRAW_VSDM]           = tr("VSDM File") + " (*.vsdm)";
@@ -472,8 +480,13 @@ void CFileDialogWrapper::setFormats(std::vector<int>& vf)
     if ( vf.size() ) {
         std::vector<int>::iterator i = vf.begin();
         m_filters = m_mapFilters.value(*(i++));
+        if ( m_filters.isEmpty() )
+            m_filters = m_mapFilters[AVS_OFFICESTUDIO_FILE_UNKNOWN];
         while (i != vf.end()) {
-            m_filters += ";;" + m_mapFilters.value(*(i++));
+            QString _filter = m_mapFilters.value(*(i++));
+            if ( _filter.isEmpty() )
+                _filter = m_mapFilters[AVS_OFFICESTUDIO_FILE_UNKNOWN];
+            m_filters += ";;" + _filter;
         }
     }
 }


### PR DESCRIPTION
Fixes the Linux xdg-desktop-portal "Save As" crash reported in bug 74361 (see ONLYOFFICE/DesktopEditors#2243).

### Problem

On Linux, when the dialog uses the xdg-desktop-portal backend, "Save As" fails with:

```
org.freedesktop.portal.Error.InvalidArgument: invalid filter: name is empty
```

and the file cannot be saved. The dialog opens fine with the GTK fallback, so only portal users are affected.

### Root cause

`CFileDialogWrapper::setFormats()` builds the filter string by concatenating `m_mapFilters` entries. Formats that are missing from the map yield an empty string, producing filter segments with an empty name:

1. The widget sends the list of supported save formats to `setFormats()`.
2. For any format not present in `m_mapFilters` (e.g. `XLSM`, `DOTM`, `POTM`, `PPSM`, `TSV`, `SCSV`, `OFORM`, `OFD`) an empty segment is appended to `m_filters`.
3. `Xdg::openXdgPortal()` splits the filter on `;;` and `parseFilterString()` builds an entry whose name is empty.
4. xdg-desktop-portal rejects the `SaveFile` call: a filter name must not be empty.

### Fix

- In `setFormats()`, fall back to the generic "All files" filter when a requested format has no entry in `m_mapFilters`, so no empty filter segment can reach the portal.
- Add the missing entries to `m_mapFilters` for the save-as formats that were absent (`.dotm`, `.xlsm`, `.potm`, `.ppsm`, `.tsv`, `.scsv`, `.oform`, `.ofd`).

### Validation

- Built the Linux desktop editors bundle from this branch (branch `master`, build_tools `release/v9.4.0`) and confirmed the new filter strings are present in the deployed binary.
- **Runtime check against xdg-desktop-portal (passed)**: launched the built binary with `--xdg-desktop-portal`, captured the `SaveFile` D-Bus call with `dbus-monitor`, and performed "Save As" from the app:
  - `SaveFile` call carried 0 filter entries with an empty name (previously the call was rejected with `invalid filter: name is empty`).
  - No error was returned by the portal and the file was saved successfully.
- The fix is a no-op for the GTK/`QFileDialog` path.